### PR TITLE
updated testecases

### DIFF
--- a/bdd-feature-files/AA module/1000 Series/AA_1009_AccountsConsentFlow.feature
+++ b/bdd-feature-files/AA module/1000 Series/AA_1009_AccountsConsentFlow.feature
@@ -35,39 +35,3 @@ Feature: On calling POST Accounts Consent Flow API, verify that on sending the c
     And Verify that the Error code is InvalidCustomerAddress.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
-
-#  Scenario: 1009_4 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
-#  Set the proper customer identifier at proper AA identifier with last character removed. Verify that
-#  the error response is received.
-#    Given Calling the POST Accounts Consent Flow API.
-#    When POST action is performed.
-#    Then Verify that the reponse code 400 is received.
-#    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-#         current time stamp.
-#    And Verify that the Error code is InvalidCustomerAddress.
-#    And Verify that the version is supported version.
-#    And Verify that the txnid id is same as the txnid from request.
-
-#  Scenario: 1009_5 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
-#  Set the proper customer identifier at proper AA identifier with one character added at the end. Verify that
-#  the error response is received.
-#    Given Calling the POST Accounts Consent Flow API.
-#    When POST action is performed.
-#    Then Verify that the reponse code 400 is received.
-#    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-#         current time stamp.
-#    And Verify that the Error code is InvalidCustomerAddress.
-#    And Verify that the version is supported version.
-#    And Verify that the txnid id is same as the txnid from request.
-
-#  Scenario: 1009_6 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
-#  Ask the user to register a new customer, and validate that the consent is sending the 200 response and then
-#  ask the user to deregister it. Verify that the error response is received.
-#    Given Calling the POST Accounts Consent Flow API.
-#    When POST action is performed.
-#    Then Verify that the reponse code 400 is received.
-#    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-#         current time stamp.
-#    And Verify that the Error code is InvalidCustomerAddress.
-#    And Verify that the version is supported version.
-#    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/AA module/1000 Series/AA_1009_AccountsConsentFlow.feature
+++ b/bdd-feature-files/AA module/1000 Series/AA_1009_AccountsConsentFlow.feature
@@ -36,38 +36,38 @@ Feature: On calling POST Accounts Consent Flow API, verify that on sending the c
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 
-  Scenario: 1009_4 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
-  Set the proper customer identifier at proper AA identifier with last character removed. Verify that
-  the error response is received.
-    Given Calling the POST Accounts Consent Flow API.
-    When POST action is performed.
-    Then Verify that the reponse code 400 is received.
-    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-         current time stamp.
-    And Verify that the Error code is InvalidCustomerAddress.
-    And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
+#  Scenario: 1009_4 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
+#  Set the proper customer identifier at proper AA identifier with last character removed. Verify that
+#  the error response is received.
+#    Given Calling the POST Accounts Consent Flow API.
+#    When POST action is performed.
+#    Then Verify that the reponse code 400 is received.
+#    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
+#         current time stamp.
+#    And Verify that the Error code is InvalidCustomerAddress.
+#    And Verify that the version is supported version.
+#    And Verify that the txnid id is same as the txnid from request.
 
-  Scenario: 1009_5 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
-  Set the proper customer identifier at proper AA identifier with one character added at the end. Verify that
-  the error response is received.
-    Given Calling the POST Accounts Consent Flow API.
-    When POST action is performed.
-    Then Verify that the reponse code 400 is received.
-    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-         current time stamp.
-    And Verify that the Error code is InvalidCustomerAddress.
-    And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
+#  Scenario: 1009_5 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
+#  Set the proper customer identifier at proper AA identifier with one character added at the end. Verify that
+#  the error response is received.
+#    Given Calling the POST Accounts Consent Flow API.
+#    When POST action is performed.
+#    Then Verify that the reponse code 400 is received.
+#    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
+#         current time stamp.
+#    And Verify that the Error code is InvalidCustomerAddress.
+#    And Verify that the version is supported version.
+#    And Verify that the txnid id is same as the txnid from request.
 
-  Scenario: 1009_6 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
-  Ask the user to register a new customer, and validate that the consent is sending the 200 response and then
-  ask the user to deregister it. Verify that the error response is received.
-    Given Calling the POST Accounts Consent Flow API.
-    When POST action is performed.
-    Then Verify that the reponse code 400 is received.
-    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-         current time stamp.
-    And Verify that the Error code is InvalidCustomerAddress.
-    And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
+#  Scenario: 1009_6 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings.
+#  Ask the user to register a new customer, and validate that the consent is sending the 200 response and then
+#  ask the user to deregister it. Verify that the error response is received.
+#    Given Calling the POST Accounts Consent Flow API.
+#    When POST action is performed.
+#    Then Verify that the reponse code 400 is received.
+#    And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
+#         current time stamp.
+#    And Verify that the Error code is InvalidCustomerAddress.
+#    And Verify that the version is supported version.
+#    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/AA module/1000 Series/AA_1041_AccountsConsentFlow.feature
+++ b/bdd-feature-files/AA module/1000 Series/AA_1041_AccountsConsentFlow.feature
@@ -33,7 +33,7 @@ Feature: On calling POST Accounts Consent Flow API,  Verify that on sending cons
     Then Verify that the response code 400 is received.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
          current time stamp.
-    And Verify that the Error code is SignatureDoesNotMatch.
+    And Verify that the Error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/AA module/1000 Series/AA_1041_AccountsConsentFlow.feature
+++ b/bdd-feature-files/AA module/1000 Series/AA_1041_AccountsConsentFlow.feature
@@ -11,7 +11,6 @@ Feature: On calling POST Accounts Consent Flow API,  Verify that on sending cons
          current time stamp.
     And Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1041_2 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings,
   send one valid consent post request on the x-jws-signature header using the valid JWS signature with one character
@@ -23,7 +22,6 @@ Feature: On calling POST Accounts Consent Flow API,  Verify that on sending cons
          current time stamp.
     And Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1041_3 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings,
   send one valid consent post request on the x-jws-signature header by generating the JWS signature using a different key
@@ -35,7 +33,6 @@ Feature: On calling POST Accounts Consent Flow API,  Verify that on sending cons
          current time stamp.
     And Verify that the Error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1041_4 On calling the POST Accounts Consent Flow API, use the pre-linked user details from settings,
   send one valid consent post request on the x-jws-signature header using the valid JWS signature with a small
@@ -47,4 +44,3 @@ Feature: On calling POST Accounts Consent Flow API,  Verify that on sending cons
          current time stamp.
     And Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/AA module/1000 Series/AA_1042_GETConsentHandle.feature
+++ b/bdd-feature-files/AA module/1000 Series/AA_1042_GETConsentHandle.feature
@@ -31,7 +31,7 @@ Feature: On calling GET Consent Handle request API, verify that on sending conse
     Then Verify that the response code 400 is received.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
          current time stamp.
-    And Verify that the Error code is SignatureDoesNotMatch.
+    And Verify that the Error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/AA module/1000 Series/AA_1043_GETConsentId.feature
+++ b/bdd-feature-files/AA module/1000 Series/AA_1043_GETConsentId.feature
@@ -37,7 +37,7 @@ Feature: On calling GET Consent Id request API, verify that on sending consent G
     Then Verify that the response code 400 is received.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
          current time stamp.
-    And Verify that the Error code is SignatureDoesNotMatch.
+    And Verify that the Error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/AA module/2000 Series/AA_2046_POST FI Request.feature
+++ b/bdd-feature-files/AA module/2000 Series/AA_2046_POST FI Request.feature
@@ -30,7 +30,7 @@ Feature: On calling POST FI fetch Request API, verify that on sending FI request
     Then Verify that the response code displayed is HTTP 400.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from current
          time stamp.
-    And Verify that the error code is SignatureDoesNotMatch.
+    And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/AA module/2000 Series/AA_2046_POST FI Request.feature
+++ b/bdd-feature-files/AA module/2000 Series/AA_2046_POST FI Request.feature
@@ -10,7 +10,6 @@ Feature: On calling POST FI fetch Request API, verify that on sending FI request
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2046_2 POST FI fetch Request API, use the pre-linked user details from settings, set a valid FI request. Use
   the valid JWS signature and remove the last character at the end and send on the x-jws-signature header.
@@ -21,7 +20,6 @@ Feature: On calling POST FI fetch Request API, verify that on sending FI request
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2046_3 POST FI fetch Request API, use the pre-linked user details from settings, set a valid FI request.
   Generate the JWS signature using a different key that is not used for anything and send on the x-jws-signature header.
@@ -32,7 +30,6 @@ Feature: On calling POST FI fetch Request API, verify that on sending FI request
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2046_4 POST FI fetch Request API, use the pre-linked user details from settings, set a valid FI request.
   Use the valid JWS signature, make a small change in the request body data and send on the x-jws-signature header.
@@ -43,4 +40,3 @@ Feature: On calling POST FI fetch Request API, verify that on sending FI request
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/AA module/2000 Series/AA_2048_POST FI Request.feature
+++ b/bdd-feature-files/AA module/2000 Series/AA_2048_POST FI Request.feature
@@ -34,7 +34,7 @@ Feature: On calling GET FI fetch Request API, verify that on sending FI fetch re
     Then Verify that the response code displayed is HTTP 400.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from current
          time stamp.
-    And Verify that the error code is SignatureDoesNotMatch.
+    And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
 
   Scenario: 2048_4 GET FI fetch Request API, use the pre-linked user details from settings and set a valid FI response

--- a/bdd-feature-files/AA module/2000 Series/AA_2052_GET FI Request.feature
+++ b/bdd-feature-files/AA module/2000 Series/AA_2052_GET FI Request.feature
@@ -10,5 +10,5 @@ the error response is received.
     Then Verify that the response code displayed is HTTP 400.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from current
          time stamp.
-    And Verify that the error code is InvalidRequest.
+    And Verify that the error code is InvalidRequest/SignatureDoesNotMatch.
     And Verify that the version is supported version.

--- a/bdd-feature-files/AA module/3000 Series/AA_3032_POSTConsentNotification.feature
+++ b/bdd-feature-files/AA module/3000 Series/AA_3032_POSTConsentNotification.feature
@@ -39,7 +39,7 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
     Then Verify that the response code displayed is HTTP 400.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from current
          time stamp.
-    And Verify that the error code is SignatureDoesNotMatch.
+    And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/AA module/3000 Series/AA_3032_POSTConsentNotification.feature
+++ b/bdd-feature-files/AA module/3000 Series/AA_3032_POSTConsentNotification.feature
@@ -13,7 +13,6 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3032_2 On calling POST Consent Notification API, use the pre-linked user details from settings. Set the
   POST consent response in FIP mock server and send a valid consent request. Ask the user to approve the consent and
@@ -27,7 +26,6 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3032_3 On calling POST Consent Notification API, use the pre-linked user details from settings. Set the
   POST consent response in FIP mock server and send a valid consent request. Ask the user to approve the consent and
@@ -41,7 +39,6 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3032_4 On calling POST Consent Notification API, use the pre-linked user details from settings. Set the
   POST consent response in FIP mock server and send a valid consent request. Ask the user to approve the consent and
@@ -55,4 +52,3 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/AA module/3000 Series/AA_3033_POST FI Notification.feature
+++ b/bdd-feature-files/AA module/3000 Series/AA_3033_POST FI Notification.feature
@@ -11,7 +11,6 @@ Feature: On calling POST FI Notification API, verify that on sending consent not
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3033_2 On calling POST FI Notification API, Use the pre-generated consent details from settings. Set a
   valid FI response in mock FIP and send a valid FI request to AA. Finally send a FI notification request and use the
@@ -23,7 +22,6 @@ Feature: On calling POST FI Notification API, verify that on sending consent not
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3033_3 On calling POST FI Notification API, Use the pre-generated consent details from settings. Set a
   valid FI response in mock FIP and send a valid FI request to AA. Finally send a FI notification request and generate
@@ -35,7 +33,6 @@ Feature: On calling POST FI Notification API, verify that on sending consent not
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3033_4 On calling POST FI Notification API, Use the pre-generated consent details from settings. Set a
   valid FI response in mock FIP and send a valid FI request to AA. Finally send a FI notification request and use the
@@ -47,4 +44,3 @@ Feature: On calling POST FI Notification API, verify that on sending consent not
          time stamp.
     And Verify that the error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/AA module/3000 Series/AA_3033_POST FI Notification.feature
+++ b/bdd-feature-files/AA module/3000 Series/AA_3033_POST FI Notification.feature
@@ -33,7 +33,7 @@ Feature: On calling POST FI Notification API, verify that on sending consent not
     Then Verify that the response code displayed is HTTP 400.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from current
          time stamp.
-    And Verify that the error code is SignatureDoesNotMatch.
+    And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/AA module/3000 Series/AA_3034_POSTAccountLink Notification.feature
+++ b/bdd-feature-files/AA module/3000 Series/AA_3034_POSTAccountLink Notification.feature
@@ -39,7 +39,7 @@ Feature: On calling POST Account Link Notification API, verify that on sending a
     Then Verify that the response code displayed is HTTP 400.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from current
          time stamp.
-    And Verify that the error code is SignatureDoesNotMatch.
+    And Verify that the error code is SignatureDoesNotMatch/InvalidRequest.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.
 

--- a/bdd-feature-files/FIPModule/1000 Series/FIP_1056_POST AccountsDiscover.feature
+++ b/bdd-feature-files/FIPModule/1000 Series/FIP_1056_POST AccountsDiscover.feature
@@ -10,7 +10,6 @@ Feature: On Calling POST Account discovery API with invalid JWS API signature, e
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1056_2 Use a single account user with first supported FIType and send one valid account discover
   request. Send Account discover request with valid details by using the valid JWS signature but remove the
@@ -22,7 +21,6 @@ Feature: On Calling POST Account discovery API with invalid JWS API signature, e
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1056_3 Use a single account user with first supported FIType and send one valid account discover
   request. Send Account discover request with valid details by generating the JWS signature using a different
@@ -34,7 +32,6 @@ Feature: On Calling POST Account discovery API with invalid JWS API signature, e
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1056_4 Use a single account user with first supported FIType and send one valid account discover
   request. Send Account discover request with valid details by using the valid JWS signature, but do a small
@@ -46,4 +43,3 @@ Feature: On Calling POST Account discovery API with invalid JWS API signature, e
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/1000 Series/FIP_1057_POST AccountsLinking.feature
+++ b/bdd-feature-files/FIPModule/1000 Series/FIP_1057_POST AccountsLinking.feature
@@ -10,7 +10,6 @@ Feature: On Calling POST Account Link API with invalid JWS API signature, error 
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1057_2 Use a single user account with first supported FIType and send single account link request.
   Send Account Link request with valid details by using the valid JWS signature but remove one char from
@@ -22,7 +21,6 @@ Feature: On Calling POST Account Link API with invalid JWS API signature, error 
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1057_3 Use a single user account with first supported FIType and send single account link request.
   Send Account Link request with valid details by generating the JWS signature using a different key that is
@@ -34,7 +32,6 @@ Feature: On Calling POST Account Link API with invalid JWS API signature, error 
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1057_4 Use a single user account with first supported FIType and send single account link request.
   Send Account Link request with valid details by using the valid JWS signature, but do a small change in the
@@ -46,4 +43,3 @@ Feature: On Calling POST Account Link API with invalid JWS API signature, error 
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/1000 Series/FIP_1058_DeleteAccountsLinking.feature
+++ b/bdd-feature-files/FIPModule/1000 Series/FIP_1058_DeleteAccountsLinking.feature
@@ -10,7 +10,6 @@ Feature: On Calling Account de-link request with invalid JWS API signature, erro
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1058_2 Use a single user account with first supported FIType, send an account link request, send
   an account link token request. Send Account de-link request with valid details by Using the valid JWS
@@ -22,7 +21,6 @@ Feature: On Calling Account de-link request with invalid JWS API signature, erro
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1058_3 Use a single user account with first supported FIType, send an account link request, send
   an account link token request. Send Account de-link request with valid details by Generating the JWS
@@ -35,7 +33,6 @@ Feature: On Calling Account de-link request with invalid JWS API signature, erro
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 1058_4 Use a single user account with first supported FIType, send an account link request, send
   an account link token request. Send Account de-link request with valid details by using the valid JWS
@@ -47,4 +44,3 @@ Feature: On Calling Account de-link request with invalid JWS API signature, erro
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/2000 Series/FIP_2026_POST Consent.feature
+++ b/bdd-feature-files/FIPModule/2000 Series/FIP_2026_POST Consent.feature
@@ -10,7 +10,6 @@ Feature: On Calling POST Consent request with invalid JWS API signature, error r
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2026_2 Use the pre-linked user details from settings and send a valid consent with following
   variations on the x-jws-signature header. Send POST Account Consent request with valid details by Using
@@ -22,7 +21,6 @@ Feature: On Calling POST Consent request with invalid JWS API signature, error r
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2026_3 Use the pre-linked user details from settings and send a valid consent with following
   variations on the x-jws-signature header. Send POST Account Consent request with valid details by
@@ -35,7 +33,6 @@ Feature: On Calling POST Consent request with invalid JWS API signature, error r
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2026_4 Use the pre-linked user details from settings and send a valid consent with following
   variations on the x-jws-signature header. Send POST Account Consent request with valid details by using
@@ -48,4 +45,3 @@ Feature: On Calling POST Consent request with invalid JWS API signature, error r
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/2000 Series/FIP_2027_POST ConsentNotification.feature
+++ b/bdd-feature-files/FIPModule/2000 Series/FIP_2027_POST ConsentNotification.feature
@@ -11,7 +11,6 @@ Feature: On Calling POST Consent Notification request with invalid JWS API signa
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2027_2 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send a valid consent request and then send a valid consent notification request with following
@@ -25,7 +24,6 @@ Feature: On Calling POST Consent Notification request with invalid JWS API signa
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2027_3 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send a valid consent request and then send a valid consent notification request with following
@@ -39,7 +37,6 @@ Feature: On Calling POST Consent Notification request with invalid JWS API signa
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 2027_4 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send a valid consent request and then send a valid consent notification request with following
@@ -53,4 +50,3 @@ Feature: On Calling POST Consent Notification request with invalid JWS API signa
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/3000 Series/FIP_3002_POST FiRequest.feature
+++ b/bdd-feature-files/FIPModule/3000 Series/FIP_3002_POST FiRequest.feature
@@ -11,7 +11,6 @@ Feature: On Calling POST FI Request  with null values, empty string, empty array
   the current time stamp.
     And  Verify that the Error code is InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3002_2 Use the pre-linked user details from settings,set Consent/notification response in mock
   server, send one valid consent post request and then try the following. Send POST FIRequest with Empty
@@ -23,4 +22,3 @@ Feature: On Calling POST FI Request  with null values, empty string, empty array
   the current time stamp.
     And  Verify that the Error code is InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/3000 Series/FIP_3003_POST FiRequest.feature
+++ b/bdd-feature-files/FIPModule/3000 Series/FIP_3003_POST FiRequest.feature
@@ -12,7 +12,6 @@ Feature: On Calling POST FI Request with timestamp fields in different formats a
   the current time stamp.
     And  Verify that the Error code is InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3003_2 Use the pre-linked user details from settings,set Consent/notification response in mock
   server, send one valid consent post request and then try the following. Send POST Account FIRequest with
@@ -25,7 +24,6 @@ Feature: On Calling POST FI Request with timestamp fields in different formats a
   the current time stamp.
     And  Verify that the Error code is InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3003_3 Use the pre-linked user details from settings,set Consent/notification response in mock
   server, send one valid consent post request and then try the following. Send POST Account FIRequest with
@@ -38,4 +36,3 @@ Feature: On Calling POST FI Request with timestamp fields in different formats a
   the current time stamp.
     And  Verify that the Error code is InvalidRequest.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/3000 Series/FIP_3011_GET FiFetchsessionId.feature
+++ b/bdd-feature-files/FIPModule/3000 Series/FIP_3011_GET FiFetchsessionId.feature
@@ -8,10 +8,7 @@ Feature: On Calling FI Fetch request with invalid session id and check if it is 
     Given  Calling the POST FI Fetch Flow API
     When  GET action is performed.
     Then  Verify that the Response code 404 is displayed.
-    And Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
-  the current time stamp.
-    And  Verify that the Error code is InvalidSessionId.
-    And Verify that the version is supported version.
+
 
   Scenario: 3011_2 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send one valid consent post request.Set Fi/Notification response on mock server. Send the FI

--- a/bdd-feature-files/FIPModule/3000 Series/FIP_3021_POST FiRequest.feature
+++ b/bdd-feature-files/FIPModule/3000 Series/FIP_3021_POST FiRequest.feature
@@ -11,7 +11,6 @@ Feature: On Calling POST FI Request with invalid JWS API signature, error respon
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3021_2 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send a valid consent request and then send a valid FI request with following variations on the
@@ -24,7 +23,6 @@ Feature: On Calling POST FI Request with invalid JWS API signature, error respon
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3021_3 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send a valid consent request and then send a valid FI request with following variations on the
@@ -37,7 +35,6 @@ Feature: On Calling POST FI Request with invalid JWS API signature, error respon
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.
 
   Scenario: 3021_4 Use the pre-linked user details from settings, set Consent/notification response in mock
   server, send a valid consent request and then send a valid FI request with following variations on the
@@ -50,4 +47,3 @@ Feature: On Calling POST FI Request with invalid JWS API signature, error respon
   the current time stamp.
     And  Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIPModule/3000 Series/FIP_3027_GET FiFetchsessionId.feature
+++ b/bdd-feature-files/FIPModule/3000 Series/FIP_3027_GET FiFetchsessionId.feature
@@ -11,5 +11,5 @@ Feature: Verify that on sending valid FI fetch request of regular AA with JWS si
     Then  Verify that the Response code 400 is displayed.
     And Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
   the current time stamp.
-    And  Verify that the Error code is InvalidRequest.
+    And  Verify that the Error code is InvalidRequest/SignatureDoesNotMatch.
     And Verify that the version is supported version.

--- a/bdd-feature-files/FIU Module/1000 Series/FIU_1036__POST _ConsentNotification.feature
+++ b/bdd-feature-files/FIU Module/1000 Series/FIU_1036__POST _ConsentNotification.feature
@@ -11,4 +11,3 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
          current time stamp.
     And Verify that the Error code is  SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIU Module/1000 Series/FIU_1043__POST _ConsentNotification.feature
+++ b/bdd-feature-files/FIU Module/1000 Series/FIU_1043__POST _ConsentNotification.feature
@@ -11,4 +11,3 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
   the current time stamp.
     And  Verify that the Error code is InvalidRequest/SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIU Module/1000 Series/FIU_1043__POST _ConsentNotification.feature
+++ b/bdd-feature-files/FIU Module/1000 Series/FIU_1043__POST _ConsentNotification.feature
@@ -6,4 +6,9 @@ Feature: On calling POST Consent Notification API, verify that on sending consen
   status as ACTIVE with Alternate AA api key. Verify that the error response is received.
     Given Calling the POST Consent Notification API.
     When POST action is performed.
-    Then Verify that the error response is received.
+    Then  Verify that the Response code 400 is displayed.
+    And Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes from
+  the current time stamp.
+    And  Verify that the Error code is InvalidRequest/SignatureDoesNotMatch.
+    And Verify that the version is supported version.
+    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIU Module/2000 Series/FIU_2027_POST _FINotification.feature
+++ b/bdd-feature-files/FIU Module/2000 Series/FIU_2027_POST _FINotification.feature
@@ -11,4 +11,3 @@ Feature: On calling POST FI notification request API, verify that on sending FI 
   from the current time stamp.
     And Verify that the Error code is SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIU Module/2000 Series/FIU_2029_POST _FINotification.feature
+++ b/bdd-feature-files/FIU Module/2000 Series/FIU_2029_POST _FINotification.feature
@@ -12,4 +12,3 @@ Feature: On calling POST FI notification request API, verify that on sending FI 
         from the current time stamp.
     And Verify that the Error code is InvalidRequest/SignatureDoesNotMatch.
     And Verify that the version is supported version.
-    And Verify that the txnid id is same as the txnid from request.

--- a/bdd-feature-files/FIU Module/2000 Series/FIU_2029_POST _FINotification.feature
+++ b/bdd-feature-files/FIU Module/2000 Series/FIU_2029_POST _FINotification.feature
@@ -10,6 +10,6 @@ Feature: On calling POST FI notification request API, verify that on sending FI 
     Then Verify that the response code 400 is displayed.
     And  Verify that the timestamp has the exact format, and the timestamp is in "+15" or "-15" minutes
         from the current time stamp.
-    And Verify that the Error code is InvalidRequest.
+    And Verify that the Error code is InvalidRequest/SignatureDoesNotMatch.
     And Verify that the version is supported version.
     And Verify that the txnid id is same as the txnid from request.


### PR DESCRIPTION
1. Based on the recent discussion between Sahamati and Aujas, we have made the required changes in all three modules error 
    codes. Following are the TS details: 
    FIP: 3027
    FIU: 1043, 2029 
    AA: 1041_3, 1042_3, 1043_3, 2046_3, 2048_3, 3033_3, 3034_3, 3032_3, 2052

2. Removed test in AA module : 1009_4, 1009_5, 1009_6

3. Txnid validation has removed in few TS below are the following TS details 
    FIP: 1056, 1057, 1058, 2026, 2027, 3002, 3003, 3021. 
    FIU: 1036, 1043, 2027, 2029.
    AA: 1041, 2046, 3032, 3033.